### PR TITLE
serialize to standard json state files

### DIFF
--- a/src/runner/cli.ts
+++ b/src/runner/cli.ts
@@ -36,11 +36,10 @@ dirs:
   await Bun.write(path.join(options.dir, "openfn.yaml"), openfnyml);
 
   // Checkout the target so we're ready to merge
-  console.log(`${command} checkout ${source} ${log}`);
-  await $`${command} checkout ${source} ${log}`.cwd(options.dir);
+  await $`${command} checkout ${source}.json ${log}`.cwd(options.dir);
 
   // now merge
-  await $`${command} merge ${target} ${log}`.cwd(options.dir);
+  await $`${command} merge ${target}.json ${log}`.cwd(options.dir);
 
   // Now return a project based on the filesystem
   // (remember that merge doesn't update the project file)

--- a/src/test.ts
+++ b/src/test.ts
@@ -19,9 +19,9 @@ export class Context {
   }
   // serialize a project into a yaml file
   async serialize(name: string, project: Project) {
-    const yaml = project.serialize("state"); // v1 state file (v2 state will be better)
-    await this.createFile(`${name}.yaml`, yaml);
-    return yaml;
+    const state = project.serialize("state", { format: "json" }); // v1 state file (v2 state will be better)
+    await this.createFile(`${name}.json`, JSON.stringify(state, null, 2));
+    return state;
   }
 }
 

--- a/stories/merge/examples.test.ts
+++ b/stories/merge/examples.test.ts
@@ -71,7 +71,7 @@ test("should merge two workflows", async (ctx) => {
   // This needs to return the merged statefile
   // TODO should write state.json files,
   // so that CLI and Prov use _exactly_ the same input
-  const result = await runner.merge("staging.yaml", "main.yaml", {
+  const result = await runner.merge("staging", "main", {
     dir: ctx.root,
   });
 


### PR DESCRIPTION
Use regular json state files instead of yaml. This is because lightning MUST use json state files as inputs